### PR TITLE
add closing / to the returned hash-url

### DIFF
--- a/lib/hyper/struct.js
+++ b/lib/hyper/struct.js
@@ -33,7 +33,7 @@ class HyperStructure extends EventEmitter {
   }
 
   get url () {
-    return `hyper://${this.keyStr}`
+    return `hyper://${this.keyStr}/`
   }
 
   get core () {


### PR DESCRIPTION
1. for consistency, most(?) places, including beaker address bar, print/show hash-url with closing `/`, i.e.

```sh
> hyp sync ./ `cat ./.hyper` -y
Source: ./
Target: hyper://4fe8d269555b9dbf639ec1c60f1860a5528f78ae9f10d14fe7d9c73796037ab2/
Syncing...
4fe8d2..b2: Announced to seed
Synced
```

2. visual insurance too – people copy-pasting it will be certain they got the entire url, and not just the first `n-1` letters of the hash

regexps parsing the output were likely only looking for `hyper://\w+` 
