### PR TITLE
Switch daemon to manual start rather than automatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Requires nodejs 14+
 npm install -g @hyperspace/cli
 ```
 
+To start using the network, run:
+
+```
+hyp daemon start
+```
+
+This will run in the background, sync data for you, until you run:
+
+```
+hyp daemon stop
+```
+
 ## Usage
 
 Command overview:

--- a/bin/hyp.js
+++ b/bin/hyp.js
@@ -110,7 +110,7 @@ function wrapCommand (obj) {
       console.error('')
       console.error('  hyp daemon start')
       console.error('')
-      process.exit(1)
+      process.exit(2)
     }
 
     try {

--- a/bin/hyp.js
+++ b/bin/hyp.js
@@ -105,6 +105,15 @@ function wrapCommand (obj) {
       if (!obj.name.startsWith('daemon') && obj.name !== 'beam') {
         await hyper.setup()
       }
+    } catch (err) {
+      console.error('The daemon is not active. Please run:')
+      console.error('')
+      console.error('  hyp daemon start')
+      console.error('')
+      process.exit(1)
+    }
+
+    try {
       await innerCommand(...args)
     } catch (err) {
       console.error('Error:', err.message)

--- a/lib/commands/daemon/start.js
+++ b/lib/commands/daemon/start.js
@@ -15,7 +15,7 @@ export default {
     full: FULL_USAGE
   },
   command: async function (args) {
-    await setup()
+    await setup({canStartDaemon: true})
     try {
       const client = new HyperspaceClient()
       await client.ready()

--- a/lib/hyper/index.js
+++ b/lib/hyper/index.js
@@ -12,12 +12,12 @@ const RETRY_DELAY = 100
 var clients = new Map()
 var running = new Set()
 
-export async function setup () {
-  await setupClient('hyperspace', 'Hyperspace', () => new HyperspaceClient())
-  await setupClient('hyperspace-mirroring-service', 'Mirroring', () => new MirroringClient())
+export async function setup ({canStartDaemon} = {canStartDaemon: false}) {
+  await setupClient('hyperspace', 'Hyperspace', () => new HyperspaceClient(), canStartDaemon)
+  await setupClient('hyperspace-mirroring-service', 'Mirroring', () => new MirroringClient(), canStartDaemon)
 }
 
-async function setupClient (name, readable, clientFunc) {
+async function setupClient (name, readable, clientFunc, canStartDaemon = false) {
   let retries = 0
   while (!clients.get(name) && retries++ < NUM_RETRIES) {
     try {
@@ -25,6 +25,7 @@ async function setupClient (name, readable, clientFunc) {
       await client.ready()
       clients.set(name, client)
     } catch {
+      if (!canStartDaemon) break
       if (!running.has(name)) {
         await startDaemon(name, readable)
         running.add(name)
@@ -32,7 +33,9 @@ async function setupClient (name, readable, clientFunc) {
       await wait(RETRY_DELAY * retries)
     }
   }
-  if (!clients.has(name)) throw new Error(`Could not connect to the ${readable} daemon.`)
+  if (!clients.has(name)) {
+    throw new Error(`Could not connect to the ${readable} daemon.`)
+  }
 
   const cleanup = async () => {
     const client = clients.get(name)


### PR DESCRIPTION
Some folks integrating Hyper into Nix were having trouble with the CLI's automatic daemon init and requested we change to manual daemon start only. @mafintosh and I saw now problem with this, though it will need to be a major version bump.

For general errors, hyp exits with code 1. For daemon-not-active, it exits with code 2. That may be useful for anybody orchestrating the daemon to know.